### PR TITLE
Use updated NPM version

### DIFF
--- a/template.js
+++ b/template.js
@@ -72,7 +72,7 @@ exports.template = function(grunt, init, done) {
       "grunt-component-build": "~0.2.7",
       "grunt-contrib-uglify": "~0.2.0",
       "grunt-contrib-watch": "~0.3.1",
-      "component-json": "git://github.com/CamShaft/component-json.git",
+      "component-json": "~0.1.4",
       "grunt-combine": "~0.8.3",
       "grunt-component": "~0.1.2"
     };


### PR DESCRIPTION
Latest just got pushed to NPM: https://github.com/CamShaft/component-json/commit/2f1cdce0189830520e1d93746a568b2ed4099cdc

Plus, somehow I was getting permission problem using the read-only github version even though that it is, um, read-only. Specifically:

```
npm ERR! git fetch -a origin (git://github.com/CamShaft/component-json.git) error: insufficient permission for adding an object to repository database ./objects
npm ERR! git fetch -a origin (git://github.com/CamShaft/component-json.git) fatal: failed to write object
npm ERR! git fetch -a origin (git://github.com/CamShaft/component-json.git) fatal: unpack-objects failed
npm ERR! Error: `git "fetch" "-a" "origin"` failed with 128
npm ERR!     at ChildProcess.<anonymous> (/usr/local/lib/node_modules/npm/lib/utils/exec.js:59:20)
npm ERR!     at ChildProcess.EventEmitter.emit (events.js:98:17)
npm ERR!     at maybeClose (child_process.js:730:16)
npm ERR!     at Process.ChildProcess._handle.onexit (child_process.js:797:5)
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>
```
