### PR TITLE
Use HTTP for git clone in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you haven't already done so, install [grunt-init][].
 Once grunt-init is installed, place this template in your `~/.grunt-init/` directory. It's recommended that you use git to clone this template into that directory, as follows:
 
 ```
-git clone git@github.com:noflo/grunt-init-noflo.git ~/.grunt-init/noflo
+git clone https://github.com/noflo/grunt-init-noflo.git ~/.grunt-init/noflo
 ```
 
 _(Windows users, see [the documentation][grunt-init] for the correct destination directory path)_


### PR DESCRIPTION
This is just a minor annoyance for easy copy-pasting, as most of us don't have a read-only access to this repository.
